### PR TITLE
Ability to Disable Remote Cache via Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ This can be benficial for some CI cases you want to run without using the remote
 ```
 export NX_SKIP_REMOTE_CACHE=true
 ```
+
+```
+NX_SKIP_REMOTE_CACHE=true nx run project:target
+```

--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ run a build and see if files end up in your cache storage bucket:
 ```
 nx run-many --target=build --all
 ```
+
+## Options
+Using NX_SKIP_REMOTE_CACHE for temporary disabling remote cache. while keeping the local cache in tact
+This can be benficial for some CI cases you want to run without using the remote cache.
+```
+export NX_SKIP_REMOTE_CACHE=true
+```

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ nx run-many --target=build --all
 ```
 
 ## Options
-Using NX_SKIP_REMOTE_CACHE for temporary disabling remote cache. while keeping the local cache in tact
-This can be benficial for some CI cases you want to run without using the remote cache.
+
+Use NX_SKIP_REMOTE_CACHE environment variable for temporary disabling remote cache, while keeping the local cache in tact.
+This can be beneficial for some CI cases you want to run without using the remote cache.
+
 ```
 export NX_SKIP_REMOTE_CACHE=true
+nx run project:target
 ```
 
 ```

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ export default function runner(
     return defaultTaskRunner(tasks, { ...options, remoteCache: { retrieve, store } }, context);
 
     async function retrieve(hash: string, cacheDirectory: string): Promise<boolean> {
-        if (process.env.NX_SKIP_REMOTE_CACHE) return false;
+        if (process.env.NX_SKIP_REMOTE_CACHE === 'true') return false;
         try {
             const commitFile = bucket.file(`${hash}.commit`);
             const tarFile = bucket.file(`${hash}.tar`);
@@ -51,7 +51,7 @@ export default function runner(
     }
 
     async function store(hash: string, cacheDirectory: string): Promise<boolean> {
-        if (process.env.NX_SKIP_REMOTE_CACHE) return false;
+        if (process.env.NX_SKIP_REMOTE_CACHE === 'true') return false;
         try {
             await Promise.all([
                 pipeline(tar.pack(join(cacheDirectory, hash)), bucket.file(`${hash}.tar`).createWriteStream()),

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ export default function runner(
     return defaultTaskRunner(tasks, { ...options, remoteCache: { retrieve, store } }, context);
 
     async function retrieve(hash: string, cacheDirectory: string): Promise<boolean> {
+        if (process.env.NX_SKIP_REMOTE_CACHE) return false;
         try {
             const commitFile = bucket.file(`${hash}.commit`);
             const tarFile = bucket.file(`${hash}.tar`);
@@ -50,6 +51,7 @@ export default function runner(
     }
 
     async function store(hash: string, cacheDirectory: string): Promise<boolean> {
+        if (process.env.NX_SKIP_REMOTE_CACHE) return false;
         try {
             await Promise.all([
                 pipeline(tar.pack(join(cacheDirectory, hash)), bucket.file(`${hash}.tar`).createWriteStream()),


### PR DESCRIPTION
## What
Introduce an environment variable (e.g., NX_SKIP_REMOTE_CACHE) that allows disabling the remote cache. When this variable is set, the system should utilize the local cache but refrain from interacting with the remote cache.

## Motivation
While NX provides the NX_SKIP_NX_CACHE environment variable to disable caching entirely, there are scenarios where disabling only the remote cache is desirable while still benefiting from the local cache.

### Examples
1. In CI environments when connection issues occur.
2. When dealing with a corrupted cache key.
3. To verify that a failure is not related to a cache issue.
4. When there are missing input keys.


Thank you for the great package! 🙏
